### PR TITLE
Video streaming fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Older verion using API 2.0: [homebridge-foscam2](https://github.com/luisiam/home
 **Pairing PIN is the same as the HomeBridge pairing PIN.**
 
 # Important Notice
-Currently, streaming only works on iOS 10.0. iOS 10.1+ enforces SRTP which is not implemented in the current streaming library. In addition, Foscam C1 streaming will not even work on iOS 10.0 due to funky firmware. Other than streaming, all the other functionalities should work as expected.
+This version replaced `homebridge-foscam-stream` with `homebridge-camera-ffmpeg`.  You will need to add a videoConfig section to your `config.json`.  
+See [homebridge-camera-ffmpeg](https://github.com/KhaosT/homebridge-camera-ffmpeg) for configuration instructions.
 
 # Prerequisites
 1. Node.js **v6.6.0** or above
@@ -33,7 +34,15 @@ Edit your `config.json` accordingly. Configuration sample:
         "port": 88,
         "stay": 13,
         "away": 15,
-        "night": 14
+        "night": 14,
+        "videoConfig": {
+            "source": "-re -i rtsp://myfancy_rtsp_stream",
+            "stillImageSource": "-i http://faster_still_image_grab_url/this_is_optional.jpg",
+            "maxStreams": 2,
+            "maxWidth": 1280,
+            "maxHeight": 720,
+            "maxFPS": 30
+        }
     }, {
         "username": "admin2",
         "password": "password2",

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var FFMPEG = require('./ffmpeg').FFMPEG
+var FFMPEG = require("homebridge-foscam-stream").FFMPEG
 var Foscam = require("foscam-client");
 var Accessory, Service, Characteristic, UUIDGen, hap;
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var FFMPEG = require("homebridge-camera-ffmpeg").FFMPEG
+var FFMPEG = require("homebridge-camera-ffmpeg").FFMPEG;
 var Foscam = require("foscam-client");
 var Accessory, Service, Characteristic, UUIDGen, hap;
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var FFMPEG = require("homebridge-foscam-stream").FFMPEG
+var FFMPEG = require("homebridge-camera-ffmpeg").FFMPEG
 var Foscam = require("foscam-client");
 var Accessory, Service, Characteristic, UUIDGen, hap;
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var FoscamAccessory = require("homebridge-foscam-stream").FoscamAccessory;
+var FFMPEG = require('./ffmpeg').FFMPEG
 var Foscam = require("foscam-client");
 var Accessory, Service, Characteristic, UUIDGen, hap;
 
@@ -70,7 +70,7 @@ FoscamPlatform.prototype.getInfo = function (cameraConfig, callback) {
     password: cameraConfig.password,
     host: cameraConfig.host,
     port: cameraConfig.port,
-    protocol: 'http',
+    protocol: cameraConfig.protocol || 'http',
     rejectUnauthorizedCerts: true
   });
 
@@ -166,30 +166,28 @@ FoscamPlatform.prototype.configureCamera = function (mac) {
   this.log("Initializing platform accessory '" + name + "'...");
 
   // Setup for FoscamAccessory
-  var cameraSource = new FoscamAccessory(hap, thisCamera, this.log);
-  cameraSource.info().then(function () {
-    // Setup accessory as CAMERA (17) category
-    var newAccessory = new Accessory(name, uuid, 17);
-    newAccessory.configureCameraSource(cameraSource);
+  var videoProcessor = self.config.videoProcessor || 'ffmpeg';
+  var cameraSource = new FFMPEG(hap, thisCamera, self.log, videoProcessor);
+  var newAccessory = new Accessory(name, uuid, hap.Accessory.Categories.CAMERA);
+  newAccessory.configureCameraSource(cameraSource);
 
-    // Add HomeKit Security System Service
-    newAccessory.addService(Service.SecuritySystem, name + " Motion Detection");
+  // Add HomeKit Security System Service
+  newAccessory.addService(Service.SecuritySystem, name + " Motion Detection");
 
-    // Add HomeKit Motion Sensor Service
-    newAccessory.addService(Service.MotionSensor, name + " Motion Sensor");
+  // Add HomeKit Motion Sensor Service
+  newAccessory.addService(Service.MotionSensor, name + " Motion Sensor");
 
-    // Setup listeners for different events
-    self.setService(newAccessory, mac);
+  // Setup listeners for different events
+  self.setService(newAccessory, mac);
 
-    // Publish accessories to HomeKit
-    self.api.publishCameraAccessories("FoscamCamera", [newAccessory]);
+  // Publish accessories to HomeKit
+  self.api.publishCameraAccessories("FoscamCamera", [newAccessory]);
 
-    // Store accessory in cache
-    self.accessories[mac] = newAccessory;
+  // Store accessory in cache
+  self.accessories[mac] = newAccessory;
 
-    // Retrieve initial state
-    self.getInitState(newAccessory, thisCamera);
-  });
+  // Retrieve initial state
+  self.getInitState(newAccessory, thisCamera);
 }
 
 // Method to setup listeners for different events

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var FFMPEG = require("homebridge-camera-ffmpeg").FFMPEG;
+var FFMPEG = require("homebridge-camera-ffmpeg/ffmpeg").FFMPEG;
 var Foscam = require("foscam-client");
 var Accessory, Service, Characteristic, UUIDGen, hap;
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge-foscamcamera",
   "description": "Foscam Plugin for HomeBridge (API 2.1): https://github.com/nfarina/homebridge",
-  "version": "0.2.15",
+  "version": "0.3.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/luisiam/homebridge-foscamcamera.git"
@@ -17,6 +17,6 @@
   },
   "dependencies": {
     "foscam-client": "^0.4.0",
-    "homebridge-foscam-stream": "^0.3.11"
+    "homebridge-camera-ffmpeg": "^0.1.8"
   }
 }


### PR DESCRIPTION
After two years, the likelihood that `homebridge-foscam-stream` will get streaming working, is pretty low.  This PR replaces `homebridge-foscam-stream` with `homebridge-camera-ffmpeg` to get video streaming working.

I've tested this PR on a Raspberry Pi 3 using ffmpeg with the [hardware codecs enabled](
https://github.com/KhaosT/homebridge-camera-ffmpeg/wiki/Raspberry-PI).  Video streaming works both locally and remotely.
